### PR TITLE
Create raw schema and load raw data to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
-# Poetry files
-pyproject.toml
-poetry.lock
-
 .ipynb_checkpoints/
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,9 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Poetry files
+pyproject.toml
+poetry.lock
+
 .ipynb_checkpoints/
 logs/

--- a/dags/scripts/clever_main_pipeline.py
+++ b/dags/scripts/clever_main_pipeline.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from scripts.postgres_helper import upload_overwrite_table
+from scripts.postgres_helper import PostgresHelper
 
 def upload_to_postgres(**kwargs):
     file_name=kwargs.get('file_name')
@@ -11,4 +11,6 @@ def upload_to_postgres(**kwargs):
         escapechar="\\",
     )
 
-    upload_overwrite_table(raw_df, table_name)
+    helper = PostgresHelper()
+    helper.create_raw_schema_if_not_exists()
+    helper.upload_overwrite_table(raw_df, table_name)

--- a/dags/scripts/postgres_helper.py
+++ b/dags/scripts/postgres_helper.py
@@ -1,15 +1,24 @@
 from sqlalchemy import create_engine
+from sqlalchemy.schema import CreateSchema
 
 import scripts.constants as c
 
-def create_pg_engine():
-    # Create SQLAlchemy engine
-    engine = create_engine(
-        f'postgresql+psycopg2://{c.postgres_user}:{c.postgres_password}@{c.postgres_host}:{c.postgres_port}/{c.postgres_dbname}'
-    )
-    return engine
+class PostgresHelper:
+    def __init__(self):
+        self.engine = self._create_pg_engine()
 
-def upload_overwrite_table(df, table_name):
-    # Upload DataFrame to PostgreSQL
-    engine = create_pg_engine()
-    df.to_sql(f'{table_name}', engine, index=False, if_exists='replace')
+    def _create_pg_engine(self):
+        # Create SQLAlchemy engine
+        engine = create_engine(
+            f'postgresql+psycopg2://{c.postgres_user}:{c.postgres_password}@{c.postgres_host}:{c.postgres_port}/{c.postgres_dbname}'
+        )
+        return engine
+
+    def create_raw_schema_if_not_exists(self):
+        with self.engine.connect() as conn:
+            if not self.engine.dialect.has_schema(conn, "raw"):
+                conn.execute(CreateSchema("raw"))
+
+    def upload_overwrite_table(self, df, table_name):
+        # Upload DataFrame to PostgreSQL
+        df.to_sql(f'{table_name}',  self.engine, schema="raw", index=False, if_exists='replace')

--- a/train_of_thought.md
+++ b/train_of_thought.md
@@ -13,6 +13,18 @@
 2. Encapsulated global code in functions
 3. Removed binary / temporary files and added them to .gitignore
 
-**Note**: Made a mistake when creating a Pull Request. It went to the original repo,not the forked. you guys may wanna delete any public records so what I did is not easily accessible by other candidates
+**Note**: Made a mistake when creating a Pull Request. It went to the original repo,not the forked. You guys may wanna delete any public records so what I did is not easily accessible by other candidates
 
-## Step 2: Creating a transform pipeline (PR #2)
+## Step 2: Changing the loaded schema to `raw` (PR #2)
+
+### Reason
+
+Raw data is usually loaded to a Data Lake, or some sort of staging schema before cleasing and feature engineering.
+
+### Rationale
+
+The `raw` schema could have been created during the initialization of the environment (`docker compose up`), but that would create a dependency between the main DAG and the environment initialization. Instead, I decided to create the schema if it didn't exist already, when the data was loaded
+
+### Rafactoring
+
+- The postgres_helper module started becoming too big, so I made it into a class


### PR DESCRIPTION
### Reason

Raw data is usually loaded to a Data Lake, or some sort of staging schema before cleasing and feature engineering.

### Rationale

The `raw` schema could have been created during the initialization of the environment (`docker compose up`), but that would create a dependency between the main DAG and the environment initialization. Instead, I decided to create the schema if it didn't exist already, when the data was loaded

### Rafactoring

- The postgres_helper module started becoming too big, so I made it into a class